### PR TITLE
Upgrade from build.gradle plugin v1 to v2 format

### DIFF
--- a/DEVNOTES.txt
+++ b/DEVNOTES.txt
@@ -1,10 +1,8 @@
-## Issues with Java compile version
+## Bulding
 
-when attempting `jar` execution and you get "Unsupported class file major version 65":
+run `gradlew buildPlugin`
+the `jar` task does not build full jar anymore
 
-- Build & Execution
-  - Build Tools
-    - Gradle
-      - Gradle Jvm -> temurin 17
+Documentationn:
 
-Might have to switch to 21 when running locally against IDE
+https://plugins.jetbrains.com/docs/intellij/android-studio.html#pluginxml

--- a/build.gradle
+++ b/build.gradle
@@ -1,18 +1,17 @@
 buildscript {
     repositories {
         mavenCentral()
-        jcenter()
         maven { url 'https://www.jetbrains.com/intellij-repository/releases' }
     }
 }
 
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '2.0.0'
-    id 'org.jetbrains.intellij' version '1.13.3'
+    id 'org.jetbrains.intellij.platform' version '2.2.1'
 }
 
 group 'com.nilsenlabs.flavormatrix'
-version '1.4.0'
+version '1.4.2'
 
 Properties properties = new Properties()
 properties.load(project.rootProject.file("local.properties").newDataInputStream())
@@ -31,26 +30,15 @@ def defaultLocalStudioPath = 'd:/coding/android-studio-meerkat'
 // Also see https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#intellij-extension-localpath
 def localStudioPath = properties.get("localStudioPath") ?: defaultLocalStudioPath
 
-// Below: Meerkat 2024.3.1 Canary 3. Remember to update plugin.xml
-def targetIdeVersion = "243.21565.193"
+// Below: Meerkat 2024.3.1 Canary 9. Remember to update plugin.xml
+def targetIdeVersion = "243.22562.218"
 
-intellij {
-    // Uncomment the two lines below and remove "localPath" if you want to build for a different version than the one locally installed
-    // version = targetIdeVersion
-    // type = 'IC'                // Community edition
-
-    plugins = ['android']
-    localPath = localStudioPath
-
-    // since-build and until-build is configured in plugin.xml.
-    // Update whenever rebuilt for later IDEA version.
-    updateSinceUntilBuild = false
-}
 
 patchPluginXml {
     changeNotes = """
     <ul>
-      <li>1.4.0 Support for Android Studio Meerkat (from Canary 3)</li>
+      <li>1.4.2 Publishing technicalities - no functionality change</li>
+      <li>1.4.0 Support for Android Studio Meerkat (from Canary 9)</li>
       <li>1.3.0 Support for Android Studio Ladybug</li>
       <li>1.2.0 Support for Android Studio Giraffe and Hedgehog</li>
       <li>1.1.0 Support for Android Studio Electric Eel</li>
@@ -60,23 +48,22 @@ patchPluginXml {
     """
 }
 
-runIde {
-    def dirObj = project.getLayout().getProjectDirectory().dir(localStudioPath).asFile
-    ideDir.set(dirObj)
-}
-
-instrumentCode {
-    compilerVersion = targetIdeVersion
-}
-
 repositories {
     mavenLocal()
     mavenCentral()
-    jcenter()
+    intellijPlatform {
+        defaultRepositories()
+    }
     maven { url 'https://www.jetbrains.com/intellij-repository/releases' }
 }
 
 dependencies {
     testImplementation group: 'junit', name: 'junit', version: '4.12'
     testImplementation "org.mockito:mockito-core:2.+"
+    intellijPlatform {
+        local(localStudioPath)
+        //androidStudio("$targetIdeVersion") // If you want IntelliJ to download AS. instead of "local"
+        bundledPlugin('com.intellij.gradle')
+        plugin("org.jetbrains.android:$targetIdeVersion")
+    }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip

--- a/src/main/java/com/nilsenlabs/flavormatrix/actions/AndroidModuleHelper.kt
+++ b/src/main/java/com/nilsenlabs/flavormatrix/actions/AndroidModuleHelper.kt
@@ -1,9 +1,7 @@
 package com.nilsenlabs.flavormatrix.actions
 
 import com.android.tools.idea.gradle.project.model.GradleAndroidModel
-import com.android.tools.idea.projectsystem.gradle.getHolderModule
 import com.intellij.openapi.module.Module
-import kotlin.streams.toList
 
 object AndroidModuleHelper {
     fun createDimensionTable(androidModules: List<GradleAndroidModel>, modules: Array<Module>): DimensionList {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -17,7 +17,7 @@
     <id>com.nilsenlabs.flavormatrix</id>
     <name>Build Variant Matrix Selector</name>
     <vendor url="https://github.com/Nilzor/build-variant-matrix">Frode Nilsen</vendor>
-    <idea-version since-build="243.21565.193" />
+    <idea-version since-build="243.22562.218" />
     <description><![CDATA[<p>Select variant by selecting flavors in a matrix instead of through the drop down lists provdided by IntelliJ/Android Studio
 in the "Build Variants" view. In addition this plugin selects variants for all modules at the same time, even
 when there are multiple leaf modules. This results in a very fast and intuitive way of switching variants


### PR DESCRIPTION
bump major version of `org.jetbrains.intellij` from 1 to 2 and support the new build.gradle syntax 