### PR TITLE
Narwhal fix: Reintroduce buildType as part of the flavorsFromVariant return string. Essential to function

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Thants to PandoraMedia's [variant-helper-plugin](https://github.com/PandoraMedia
 
 ---
 
-## Version 1.5.0 Updates - Android Studio Compatibility & Enhancements
+## Version 1.5.1 Updates - Android Studio Compatibility & Enhancements
 
 ### Recent Changes & Challenges
 
@@ -140,7 +140,7 @@ During development, you'll need to frequently reload the plugin and restart Andr
    ```
 
 2. **Install Plugin**: 
-   - Copy `build/distributions/build-variant-matrix-1.5.0.zip` to Android Studio
+   - Copy `build/distributions/build-variant-matrix-1.5.1.zip` to Android Studio
    - Or use: File → Settings → Plugins → Install from Disk
 
 3. **Restart Android Studio** (required for plugin changes)
@@ -169,8 +169,8 @@ During development, you'll need to frequently reload the plugin and restart Andr
 #### **Build Artifacts**
 
 After successful build:
-- **Plugin ZIP**: `build/distributions/build-variant-matrix-1.5.0.zip`
-- **Plugin JAR**: `build/libs/build-variant-matrix-1.5.0.jar`
+- **Plugin ZIP**: `build/distributions/build-variant-matrix-1.5.1.zip`
+- **Plugin JAR**: `build/libs/build-variant-matrix-1.5.1.jar`
 - **Sandbox**: `build/idea-sandbox/` (for testing)
 
 The plugin has been thoroughly tested with complex Android projects and modern Android Studio versions, ensuring robust compatibility across different development environments.

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 group 'com.nilsenlabs.flavormatrix'
-version '1.5.0'
+version '1.5.1'
 
 Properties properties = new Properties()
 if (project.rootProject.file("local.properties").exists()) {
@@ -39,7 +39,7 @@ def targetIdeVersion = "251.26094.121"
 patchPluginXml {
     changeNotes = """
     <ul>
-      <li>1.5.0 Support for Android Studio Narwhal (2025.1.2)</li>
+      <li>1.5.1 Support for Android Studio Narwhal (2025.1.2)</li>
       <li>1.4.2 Publishing technicalities - no functionality change</li>
       <li>1.4.0 Support for Android Studio Meerkat (from Canary 9)</li>
       <li>1.3.0 Support for Android Studio Ladybug</li>

--- a/src/main/java/com/nilsenlabs/flavormatrix/actions/DimensionList.kt
+++ b/src/main/java/com/nilsenlabs/flavormatrix/actions/DimensionList.kt
@@ -1,27 +1,18 @@
 package com.nilsenlabs.flavormatrix.actions
 
-import kotlin.streams.toList
 
 class DimensionList {
     companion object {
         val BUILD_TYPE_NAME = "buildType"
 
+        /** Splits the flavor-buildtype-string into individual parts. e.g. qaArm64Debug -> [qa, arm64, debug] */
         fun flavorsFromVariant(variantName: String): List<String> {
             // Enhanced parsing for complex variant names like "qaArm64Debug" or "prodFreeArm32Release"
             val flavors = variantName
                 .split(Regex("(?=[A-Z])"))
                 .filter { it.isNotEmpty() }
                 .map { it.lowercase() }
-
-            // Remove build type if it's at the end (debug, release, etc.)
-            val knownBuildTypes = setOf("debug", "release")
-            val filteredFlavors = if (flavors.isNotEmpty() && knownBuildTypes.contains(flavors.last())) {
-                flavors.dropLast(1)
-            } else {
-                flavors
-            }
-
-            return filteredFlavors
+            return flavors
         }
     }
 

--- a/src/main/java/com/nilsenlabs/flavormatrix/actions/DimensionList.kt
+++ b/src/main/java/com/nilsenlabs/flavormatrix/actions/DimensionList.kt
@@ -86,7 +86,7 @@ class DimensionList {
                 }
             }.joinToString("")
 
-            println("Constructed variant for module '$moduleName': $variantString (from flavors: ${selectedFlavors.joinToString(", ")})")
+            getLog().info("Constructed variant for module '$moduleName': $variantString (from flavors: ${selectedFlavors.joinToString(", ")})")
             return variantString
 
         } catch (ex: NoSuchElementException) {

--- a/src/test/java/com/nilsenlabs/flavormatrix/MultiDimensionTest.kt
+++ b/src/test/java/com/nilsenlabs/flavormatrix/MultiDimensionTest.kt
@@ -10,11 +10,11 @@ class MultiDimensionTest {
     fun testComplexVariantNameParsing() {
         // Test parsing of complex variant names like your android-userland project might have
         val testCases = mapOf(
-            "qaArm64Debug" to listOf("qa", "arm64"),
-            "prodFreeArm32Release" to listOf("prod", "free", "arm32"),
-            "devPaidArm64Debug" to listOf("dev", "paid", "arm64"),
-            "qaDebug" to listOf("qa"),
-            "simpleRelease" to listOf("simple")
+            "qaArm64Debug" to listOf("qa", "arm64", "debug"),
+            "prodFreeArm32Release" to listOf("prod", "free", "arm32", "release"),
+            "devPaidArm64Debug" to listOf("dev", "paid", "arm64", "debug"),
+            "qaDebug" to listOf("qa", "debug"),
+            "simpleRelease" to listOf("simple", "release")
         )
 
         testCases.forEach { (variantName, expectedFlavors) ->


### PR DESCRIPTION
Reintroduce buildType as part of the flavorsFromVariant return string. Essential to function. Without it, Android Studio attempted to select variants that didn't exist. If a solutio has a variant named `qaPaidRelease`, you have to send `qaPaidRelease` as input to `LegacyBuildVariantUpdater`, not `qaPaid`. 

Tested with my test project at https://github.com/Nilzor/FlavoredProject

@SamarthaKV29  if this breaks some of your use cases please let me know. I will merge and publish this at 20:00 CET today or later if no feeddback. Change requests after that time will have to be publishes separately

Addresses #23 